### PR TITLE
bug: fix meta tags blog entry

### DIFF
--- a/content/entry/what-meta-tags-your-site-should-be-using/index.md
+++ b/content/entry/what-meta-tags-your-site-should-be-using/index.md
@@ -1,6 +1,6 @@
 ---
 title: What Meta Tags Your Site Should Be Using
-date: "2016-12-20"
+date: "2016-11-20"
 categories:
 - Talks
 tags:


### PR DESCRIPTION
Change the date of the meta tags talk entry to prevent it from colliding with the blog post of the same name (and date).

Addresses #19